### PR TITLE
Update deps and remove duplicates

### DIFF
--- a/gpg.yml
+++ b/gpg.yml
@@ -1,8 +1,8 @@
 name: gnupg
 sources:
   - type: archive
-    url: https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.7.tar.bz2
-    sha256: d95b361ee6ef7eff86af40c8c72bf9313736ac9f7010d6604d78bf83818e976e
+    url: https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.10.tar.bz2
+    sha256: 799dd37a86a1448732e339bd20440f4f5ee6e69755f6fd7a73ee8af30840c915
 modules:
   - name: libksba
     sources:
@@ -13,11 +13,11 @@ modules:
   - name: libgcypt
     sources:
       - type: archive
-        url: https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.8.2.tar.bz2
-        sha256: c8064cae7558144b13ef0eb87093412380efa16c4ee30ad12ecb54886a524c07
+        url: https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.8.3.tar.bz2
+        sha256: 66ec90be036747602f2b48f98312361a9180c97c68a690a5f376fa0f67d0af7c
 
   - name: npth
     sources:
       - type: archive
-        url: https://gnupg.org/ftp/gcrypt/npth/npth-1.5.tar.bz2
-        sha256: 294a690c1f537b92ed829d867bee537e46be93fbd60b16c04630fbbfcd9db3c2
+        url: https://gnupg.org/ftp/gcrypt/npth/npth-1.6.tar.bz2
+        sha256: 1393abd9adcf0762d34798dc34fdcf4d0d22a8410721e76f1e3afcd1daa4e2d1

--- a/org.gnome.Keysign.yml
+++ b/org.gnome.Keysign.yml
@@ -34,19 +34,6 @@ cleanup:
   - "*.la"
   - "*.a"
 modules:
-  - name: pycairo
-    buildsystem: simple
-    ensure-writable:
-      - easy-install.pth
-      - setuptools.pth
-    build-commands:
-      - python3 setup.py build
-      - python3 setup.py install --prefix=${FLATPAK_DEST}
-    sources:
-      - type: archive
-        url: https://github.com/pygobject/pycairo/releases/download/v1.13.4/pycairo-1.13.4.tar.gz
-        sha256: 9e1eb50d4b61167cfde585261d93fde6ecda08f0f6c0136d3cf92abc5eb893ed
-
   - name: python3-pytz
     buildsystem: simple
     ensure-writable:
@@ -56,20 +43,8 @@ modules:
       - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} pytz
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/10/76/52efda4ef98e7544321fd8d5d512e11739c1df18b0649551aeccfb1c8376/pytz-2018.4.tar.gz
-        sha256: c06425302f2cf668f1bba7a0a03f3c1d34d4ebeef2c72003da308b3947c7f749
-
-  - name: pygobject
-    build-options:
-      env:
-        PYTHON: python3
-    ensure-writable:
-      - easy-install.pth
-      - setuptools.pth
-    sources:
-      - type: archive
-        url: http://ftp.acc.umu.se/pub/GNOME/sources/pygobject/3.28/pygobject-3.28.2.tar.xz
-        sha256: ac443afd14fcb9ff5744b65d6e2b380e70510278404fb8684a9b9fb089e6f2ca
+        url: https://files.pythonhosted.org/packages/ca/a9/62f96decb1e309d6300ebe7eee9acfd7bccaeedd693794437005b9067b44/pytz-2018.5.tar.gz
+        sha256: ffb9ef1de172603304d9d2819af6f5ece76f2e85ec10692a524dd876e72bf277
 
   - name: swig
     config-opts:
@@ -177,25 +152,14 @@ modules:
                 url: https://github.com/ImageMagick/ImageMagick/archive/7.0.8-12.tar.gz
                 sha256: cd3a25183d433f3ad4f8ed6301c5ae5dfb0959c1f09b059acee447bb3881bf99
 
-  - name: gst-python
-    config-opts:
-      - "--with-pygi-overrides-dir=/app/lib/python3.4/site-packages/gi/overrides/"
-    ensure-writable:
-      - easy-install.pth
-      - setuptools.pth
-    sources:
-      - type: archive
-        url: https://gstreamer.freedesktop.org/src/gst-python/gst-python-1.9.1.tar.xz
-        sha256: 2ab16a84efbabacfcf8f7920ab6c6725c577f08a82bf4cee45edf415a917015f
-
   - name: python3-babel
     buildsystem: simple
     build-commands:
       - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} babel
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/0e/d5/9b1d6a79c975d0e9a32bd337a1465518c2519b14b214682ca9892752417e/Babel-2.5.3.tar.gz
-        sha256: 8ce4cb6fdd4393edd323227cba3a077bceb2a6ce5201c902c65e730046f41f14
+        url: https://files.pythonhosted.org/packages/be/cc/9c981b249a455fa0c76338966325fc70b7265521bad641bf2932f77712f4/Babel-2.6.0.tar.gz
+        sha256: 8cba50f48c529ca3fa18cf81fa9403be176d374ac4d60738b839122dfaaa3d23
 
   - name: python3-six
     buildsystem: simple
@@ -218,8 +182,8 @@ modules:
       - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} qrcode
     sources:
       - type: file
-        url: https://pypi.python.org/packages/87/16/99038537dc58c87b136779c0e06d46887ff5104eb8c64989aac1ec8cba81/qrcode-5.3.tar.gz
-        sha256: 4115ccee832620df16b659d4653568331015c718a754855caf5930805d76924e
+        url: https://files.pythonhosted.org/packages/8d/b6/beed3d50e1047a2aa6437d3a653e5f31feb7f4de8bc054299dc205682e41/qrcode-6.0.tar.gz
+        sha256: 037b0db4c93f44586e37f84c3da3f763874fcac85b2974a69a98e399ac78e1bf
 
   - name: python3-requests
     buildsystem: simple
@@ -230,26 +194,26 @@ modules:
       - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} requests
     sources:
       - type: file
-        url: https://files.pythonhosted.org/packages/4d/9c/46e950a6f4d6b4be571ddcae21e7bc846fcbb88f1de3eff0f6dd0a6be55d/certifi-2018.4.16.tar.gz
-        sha256: 13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7
+        url: https://files.pythonhosted.org/packages/e1/0f/f8d5e939184547b3bdc6128551b831a62832713aa98c2ccdf8c47ecc7f17/certifi-2018.8.24.tar.gz
+        sha256: 376690d6f16d32f9d1fe8932551d80b23e9d393a8578c5633a2ed39a64861638
       - type: file
-        url: https://files.pythonhosted.org/packages/ee/11/7c59620aceedcc1ef65e156cc5ce5a24ef87be4107c2b74458464e437a5d/urllib3-1.22.tar.gz
-        sha256: cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f
+        url: https://files.pythonhosted.org/packages/3c/d2/dc5471622bd200db1cd9319e02e71bc655e9ea27b8e0ce65fc69de0dac15/urllib3-1.23.tar.gz
+        sha256: a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf
       - type: file
-        url: https://files.pythonhosted.org/packages/f4/bd/0467d62790828c23c47fc1dfa1b1f052b24efdf5290f071c7a91d0d82fd3/idna-2.6.tar.gz
-        sha256: 2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f
+        url: https://files.pythonhosted.org/packages/65/c4/80f97e9c9628f3cac9b98bfca0402ede54e0563b56482e3e6e45c43c4935/idna-2.7.tar.gz
+        sha256: 684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16
       - type: file
         url: https://files.pythonhosted.org/packages/fc/bb/a5768c230f9ddb03acc9ef3f0d4a3cf93462473795d18e9535498c8f929d/chardet-3.0.4.tar.gz
         sha256: 84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae
       - type: file
-        url: https://files.pythonhosted.org/packages/b0/e1/eab4fc3752e3d240468a8c0b284607899d2fbfb236a56b7377a329aa8d09/requests-2.18.4.tar.gz
-        sha256: 9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e
+        url: https://files.pythonhosted.org/packages/54/1f/782a5734931ddf2e1494e4cd615a51ff98e1879cbe9eecbdfeaf09aa75e9/requests-2.19.1.tar.gz
+        sha256: ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a
 
   - name: gpgme
     sources:
       - type: archive
-        url: https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-1.11.1.tar.bz2
-        sha256: 2d1b111774d2e3dd26dcd7c251819ce4ef774ec5e566251eb9308fa7542fbd6f
+        url: https://www.gnupg.org/ftp/gcrypt/gpgme/gpgme-1.12.0.tar.bz2
+        sha256: b4dc951c3743a60e2e120a77892e9e864fb936b2e58e7c77e8581f4d050e8cd8
     modules:
       - name: libassaun
         sources:
@@ -261,8 +225,8 @@ modules:
             sources:
               - type: archive
                 # this is a mirror because ftp is not yet supported https://github.com/flatpak/flatpak-builder/issues/23
-                url: http://mirrors.dotsrc.org/gnupg/libgpg-error/libgpg-error-1.31.tar.bz2
-                sha256: 40d0a823c9329478063903192a1f82496083b277265904878f4bc09e0db7a4ef
+                url: https://mirrors.dotsrc.org/gnupg/libgpg-error/libgpg-error-1.32.tar.bz2
+                sha256: c345c5e73cc2332f8d50db84a2280abfb1d8f6d4f1858b9daa30404db44540ca
 
   - gpg.yml
 
@@ -282,8 +246,8 @@ modules:
     - "-DBUILD_SHARED_LIBS:BOOL=ON"
     sources:
     - type: archive
-      url: https://github.com/libical/libical/archive/v3.0.3.tar.gz
-      sha256: ef9f64540332c2aeb57f299a73c3b0de136f733ae61a281f449013159da94e7c
+      url: https://github.com/libical/libical/archive/v3.0.4.tar.gz
+      sha256: 20f39343701ccd3ad896a9f9e982fdf85c1d3a35572e9d962216b69a64aef2ae
 
   - name: bluez
     config-opts:
@@ -320,8 +284,8 @@ modules:
       - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} lxml
     sources:
       - type: file
-        url: https://pypi.python.org/packages/e1/4c/d83979fbc66a2154850f472e69405572d89d2e6a6daee30d18e83e39ef3a/lxml-4.1.1.tar.gz
-        sha256: 940caef1ec7c78e0c34b0f6b94fe42d0f2022915ffc78643d28538a5cfd0f40e
+        url: https://files.pythonhosted.org/packages/4b/20/ddf5eb3bd5c57582d2b4652b4bbcf8da301bdfe5d805cb94e805f4d7464d/lxml-4.2.5.tar.gz
+        sha256: 36720698c29e7a9626a0dc802ef8885f8f0239bfd1689628ecd459a061f2807f
 
   - name: python3-future
     buildsystem: simple


### PR DESCRIPTION
pycairo, pygobject and gst-python are already available in the GNOME
3.30 runtime.