### PR TITLE
 Remove redundant build flags

### DIFF
--- a/org.gnome.Keysign.yml
+++ b/org.gnome.Keysign.yml
@@ -18,8 +18,6 @@ finish-args:
 # We're waiting for webcam support: https://github.com/flatpak/xdg-desktop-portal/issues/38;
 # we use --device=all meanwhile. We do network, because we're opening a port.
 build-options:
-  cflags: -O2 -g
-  cxxflags: -O2 -g
   env:
     V: '1'
 cleanup:


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.